### PR TITLE
Removing demos and renumber

### DIFF
--- a/Instructions/Labs/01-agile-planning-management-using-github.md
+++ b/Instructions/Labs/01-agile-planning-management-using-github.md
@@ -4,7 +4,7 @@ lab:
     module: 'Plan with DevOps'
 ---
 
-# Lab 02 - Agile Planning and Management using GitHub
+# Lab 01 - Agile Planning and Management using GitHub
 
 ## Objectives
 

--- a/Instructions/Labs/02-implement-manage-repositories-using-github.md
+++ b/Instructions/Labs/02-implement-manage-repositories-using-github.md
@@ -4,7 +4,7 @@ lab:
     module: 'Develop with DevOps'
 ---
 
-# Lab 03 - Implement Flow of Work with GitHub
+# Lab 02 - Implement Flow of Work with GitHub
 
 ## Objectives
 

--- a/Instructions/Labs/03-implement-ci-cd-with-github-actions-and-iac-with-bicep.md
+++ b/Instructions/Labs/03-implement-ci-cd-with-github-actions-and-iac-with-bicep.md
@@ -4,7 +4,7 @@ lab:
     module: 'Deliver with DevOps'
 ---
 
-# Lab 04 - Implement CI/CD with GitHub Actions and IaC with Bicep
+# Lab 03 - Implement CI/CD with GitHub Actions and IaC with Bicep
 
 ## Objectives
 

--- a/index.md
+++ b/index.md
@@ -16,10 +16,10 @@ Hyperlinks to each of the lab exercises and demos are listed below.
 {% for activity in labs  %}| {{ activity.lab.module }} | [{{ activity.lab.title }}{% if activity.lab.type %} - {{ activity.lab.type }}{% endif %}]({{ site.github.url }}{{ activity.url }}) |
 {% endfor %}
 
-## Demos
+<!-- ## Demos
 
 {% assign demos = site.pages | where_exp:"page", "page.url contains '/Instructions/Demos'" %}
 | Module | Demo |
 | --- | --- | 
 {% for activity in demos  %}| {{ activity.demo.module }} | [{{ activity.demo.title }}]({{ site.github.url }}{{ activity.url }}) |
-{% endfor %}
+{% endfor %} -->


### PR DESCRIPTION
This pull request includes updates to the lab numbers and titles in the instructions files. The most important changes include updating the lab number and title in `03-implement-ci-cd-with-github-actions-and-iac-with-bicep.md`, `Instructions/Labs/01-agile-planning-management-using-github.md`, and `Instructions/Labs/02-implement-manage-repositories-using-github.md`.

Lab instructions updates:

* [`Instructions/Labs/03-implement-ci-cd-with-github-actions-and-iac-with-bicep.md`](diffhunk://#diff-356981c1a7405bd415e16c53f30444db5ddbb24820e937119addffbfa2394f92L7-R7): Updated the lab number from 04 to 03.
* [`Instructions/Labs/01-agile-planning-management-using-github.md`](diffhunk://#diff-d66802f9506ee07eb58a9590fe5e717da1a0f44963f72aaf3308bd39f2014933L7-R7): Updated the lab number and title.
* [`Instructions/Labs/02-implement-manage-repositories-using-github.md`](diffhunk://#diff-75bfafd7aeac035bade3632f01ff07125978dc1fb1766909cfc74d11640fde18L7-R7): Updated the lab number from 03 to 02 and the title.

Rendering changes:

* [`index.md`](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5L19-R25): Commented out a section related to demos, effectively hiding it from rendering.