### PR TITLE
Some updates to Lab 03 and Lab 04

### DIFF
--- a/Instructions/Labs/03-implement-ci-cd-with-github-actions-and-iac-with-bicep.md
+++ b/Instructions/Labs/03-implement-ci-cd-with-github-actions-and-iac-with-bicep.md
@@ -229,6 +229,7 @@ The exercise consists of the following tasks:
     RESOURCE-GROUP: rg-eshoponweb-eastus
    ```
 
+1. In the **Edit** pane, replace the `location` variable in line 9 with `eastus` value. 
 1. In the **Edit** pane, replace the `eshoponweb-webapp-NAME` placeholder in line 11 with the name of the **second** Azure App Service web app you generated earlier in this exercise.
 1. In the **.github/workflows/eshoponweb-cicd.yml** pane, select **Commit changes** and then select **Commit changes** again.
 1. In the web browser window displaying the forked **eShopOnWeb** GitHub repo page, select **Actions**.

--- a/Instructions/Labs/03-implement-ci-cd-with-github-actions-and-iac-with-bicep.md
+++ b/Instructions/Labs/03-implement-ci-cd-with-github-actions-and-iac-with-bicep.md
@@ -229,7 +229,7 @@ The exercise consists of the following tasks:
     RESOURCE-GROUP: rg-eshoponweb-eastus
    ```
 
-1. In the **Edit** pane, replace the `location` variable in line 9 with `eastus` value. 
+1. In the **Edit** pane, replace the `location` variable in line 9 with the region nearest to your location. 
 1. In the **Edit** pane, replace the `eshoponweb-webapp-NAME` placeholder in line 11 with the name of the **second** Azure App Service web app you generated earlier in this exercise.
 1. In the **.github/workflows/eshoponweb-cicd.yml** pane, select **Commit changes** and then select **Commit changes** again.
 1. In the web browser window displaying the forked **eShopOnWeb** GitHub repo page, select **Actions**.

--- a/Instructions/Labs/04-enhance-workload-traffic-manager-test-azure-chaos-studio.md
+++ b/Instructions/Labs/04-enhance-workload-traffic-manager-test-azure-chaos-studio.md
@@ -61,7 +61,7 @@ The exercise consists of the following tasks:
 ### Task 1: Implement a Traffic Manager profile
 
 1. In the web browser tab displaying the Azure portal, in the search text box at the top of the page, enter **`Traffic Manager profiles`** and, in the list of results, select **Traffic Manager profiles**.
-1. On the **Load Balancing Services| Traffic Manager** page, select **+ Create**.
+1. On the **Load Balancing Services \| Traffic Manager** page, select **+ Create**.
 1. On the **Create Traffic Manager profile** page, do the following actions:
 
    - In the **Name** text box, enter **`devopsfoundationstmprofile`**.

--- a/Instructions/Labs/04-enhance-workload-traffic-manager-test-azure-chaos-studio.md
+++ b/Instructions/Labs/04-enhance-workload-traffic-manager-test-azure-chaos-studio.md
@@ -80,7 +80,7 @@ The exercise consists of the following tasks:
 
    > **Note:** Wait for the deployment to complete. This should complete within a minute.
 
-1. On the **Load Balancing Services| Traffic Manager** page, if necessary, select **Refresh** and then select **devopsfoundationstmprofile**.
+1. On the **Load Balancing Services \| Traffic Manager** page, if necessary, select **Refresh** and then select **devopsfoundationstmprofile**.
 1. On the **devopsfoundationstmprofile** page, in the **Essentials** section, copy the value of the **DNS name** setting, and record it. You'll need it throughout this lab.
 1. On the **devopsfoundationstmprofile** page, in the left navigation menu, in the **Settings** section, select **Configuration**.
 1. Review the content of the **devopsfoundationstmprofile \| Configuration** page. Note that, by default, **DNS time to live (TTL)** is set to **60** seconds. Change the value to **5** seconds.

--- a/Instructions/Labs/04-enhance-workload-traffic-manager-test-azure-chaos-studio.md
+++ b/Instructions/Labs/04-enhance-workload-traffic-manager-test-azure-chaos-studio.md
@@ -80,7 +80,7 @@ The exercise consists of the following tasks:
 
    > **Note:** Wait for the deployment to complete. This should complete within a minute.
 
-1. On the **Load balancing \| Traffic Manager** page, if necessary, select **Refresh** and then select **devopsfoundationstmprofile**.
+1. On the **Load Balancing Services| Traffic Manager** page, if necessary, select **Refresh** and then select **devopsfoundationstmprofile**.
 1. On the **devopsfoundationstmprofile** page, in the **Essentials** section, copy the value of the **DNS name** setting, and record it. You'll need it throughout this lab.
 1. On the **devopsfoundationstmprofile** page, in the left navigation menu, in the **Settings** section, select **Configuration**.
 1. Review the content of the **devopsfoundationstmprofile \| Configuration** page. Note that, by default, **DNS time to live (TTL)** is set to **60** seconds. Change the value to **5** seconds.

--- a/Instructions/Labs/04-enhance-workload-traffic-manager-test-azure-chaos-studio.md
+++ b/Instructions/Labs/04-enhance-workload-traffic-manager-test-azure-chaos-studio.md
@@ -61,7 +61,7 @@ The exercise consists of the following tasks:
 ### Task 1: Implement a Traffic Manager profile
 
 1. In the web browser tab displaying the Azure portal, in the search text box at the top of the page, enter **`Traffic Manager profiles`** and, in the list of results, select **Traffic Manager profiles**.
-1. On the **Load balancing \| Traffic Manager** page, select **+ Create**.
+1. On the **Load Balancing Services| Traffic Manager** page, select **+ Create**.
 1. On the **Create Traffic Manager profile** page, do the following actions:
 
    - In the **Name** text box, enter **`devopsfoundationstmprofile`**.


### PR DESCRIPTION

## Lab/Demo: 03-04

Changes proposed in this pull request:

LAB03 - Changes to CI/CD implementation instructions:

* [`Instructions/Labs/03-implement-ci-cd-with-github-actions-and-iac-with-bicep.md`](diffhunk://#diff-356981c1a7405bd415e16c53f30444db5ddbb24820e937119addffbfa2394f92R232): Added a step to replace the `location` variable with the value `eastus` in the **Edit** pane.

LAB 04 - Changes to Traffic Manager instructions:

* [`Instructions/Labs/04-enhance-workload-traffic-manager-test-azure-chaos-studio.md`](diffhunk://#diff-706e65422120ba640d072b03a1b8825df329a3326175dd3645b0292e2767bd18L64-R64): Corrected the name of the page from **Load balancing \| Traffic Manager** to **Load Balancing Services| Traffic Manager** in the steps for creating and refreshing the Traffic Manager profile. [[1]](diffhunk://#diff-706e65422120ba640d072b03a1b8825df329a3326175dd3645b0292e2767bd18L64-R64) [[2]](diffhunk://#diff-706e65422120ba640d072b03a1b8825df329a3326175dd3645b0292e2767bd18L83-R83)